### PR TITLE
Legg til teamspesifikk jenkinsfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Det er viktig at man installerer riktig versjon. Man finner denne her på felles
 Det er lettest å starte backend og frontend helt uavhengig av hverandre når man skal teste lokalt. 
 
 Ved utvikling av frontend er et lettest å bare kjøre opp med mockdata. Dette kan gjøreds ved å
-starte opp frontenden med `npm run start-mock`. Modkdataen skal til en hver tid være representativ
+starte opp frontenden med `npm run start-mock` i `src/frontend`. Modkdataen skal til en hver tid være representativ
 for reelle data. Heroku starter opp en instans av alle pull-requestene, hvor den bruker mockdata.
 Slik at man kan få verifisert frontend-endringer funksjonelt før man merger.

--- a/src/frontend/src/mock/teams.ts
+++ b/src/frontend/src/mock/teams.ts
@@ -3,10 +3,12 @@ import { Team } from '../models/team';
 export const teams: Team[] = [
     {
         id: 'fo',
-        displayName: 'Forenklet Oppfølging'
+        displayName: 'Forenklet Oppfølging',
+        jenkinsFolder: 'forenklet_oppfolging'
     },
     {
         id: 'rocket',
-        displayName: 'Team Rocket'
+        displayName: 'Team Rocket',
+        jenkinsFolder: 'team_rocket'
     }
 ];

--- a/src/frontend/src/models/team.ts
+++ b/src/frontend/src/models/team.ts
@@ -1,4 +1,5 @@
 export interface Team {
     id: string;
     displayName: string;
+    jenkinsFolder: string;
 }

--- a/src/frontend/src/view/promote/promote.tsx
+++ b/src/frontend/src/view/promote/promote.tsx
@@ -12,7 +12,9 @@ import { selectReleaseWithCommits, selectIsLoadingRelease } from '../../redux/se
 import IssuesTable from '../release-note/kvittering/issues-table';
 import { selectIsLoadingIssues } from '../../redux/jira-issue-duck';
 import { getInfoForPromote } from '../../redux/promote-duck';
-import { TeamAwareLink, TeamAwareAnchor } from '../team-aware-link';
+import { TeamAwareLink } from '../team-aware-link';
+import { selectValgtTeam } from '../../redux/team-velger-duck';
+import { Team } from '../../models/team';
 
 interface PromoteRouteProps {
     app: string;
@@ -24,6 +26,7 @@ interface PromoteStateProps {
     release: ReleaseWithCommits;
     fromVersion: string;
     toVersion: string;
+    valgtTeam?: Team;
 }
 
 interface DispatchProps {
@@ -47,7 +50,8 @@ class Promote extends React.PureComponent<PromoteProps> {
         const app = props.release.application;
         const env = props.release.environment.promotesTo;
         const buildName = env === 'p' ? '-release-' : `-promotering-${env}-`;
-        const linkUrl = `http://bekkci.devillo.no/job/forenklet_oppfolging/job/${app}/job/${buildName}/`;
+        const jenkinsFolder = props.valgtTeam ? props.valgtTeam.jenkinsFolder : '';
+        const linkUrl = `http://bekkci.devillo.no/job/${jenkinsFolder}/job/${app}/job/${buildName}/`;
 
         return (
             <section>
@@ -58,9 +62,9 @@ class Promote extends React.PureComponent<PromoteProps> {
                     <ConmmitsForRelease commits={props.release.commits} />
                 </div>
                 <div className="knapperad-promoter">
-                    <TeamAwareAnchor className="knapp knapp--hoved" href={linkUrl} target="_blank" rel="noopener noreferrer">
+                    <a className="knapp knapp--hoved" href={linkUrl} target="_blank" rel="noopener noreferrer">
                         Promoter
-                    </TeamAwareAnchor>
+                    </a>
                     <TeamAwareLink className="knapp" to="/">
                         Avbryt
                     </TeamAwareLink>
@@ -80,7 +84,8 @@ function mapStateToProps(state: AppState, ownProps: RouteComponentProps<PromoteR
         isLoading: selectIsLoadingRelease(state) || selectIsLoadingIssues(state),
         release: selectReleaseWithCommits(state, routeParams.app, routeParams.env),
         fromVersion: deployNextEnv ? deployNextEnv.version : '',
-        toVersion: deployCurrentEnv ? deployCurrentEnv.version : ''
+        toVersion: deployCurrentEnv ? deployCurrentEnv.version : '',
+        valgtTeam: selectValgtTeam(state),
     };
 }
 

--- a/src/main/java/no/nav/fo/forenkletdeploy/teams/FOTeam.java
+++ b/src/main/java/no/nav/fo/forenkletdeploy/teams/FOTeam.java
@@ -28,6 +28,11 @@ public class FOTeam implements Team {
     }
 
     @Override
+    public String getJenkinsFolder() {
+        return "forenklet_oppfolging";
+    }
+
+    @Override
     public List<ApplicationConfig> getApplicationConfigs() {
         String json = withClient(c -> c.target("https://raw.githubusercontent.com/navikt/jenkins-dsl-scripts/master/forenklet_oppfolging/config.json").request().get(String.class));
         Map<String, Map<String, String>> map = fromJson(json, Map.class);

--- a/src/main/java/no/nav/fo/forenkletdeploy/teams/Team.java
+++ b/src/main/java/no/nav/fo/forenkletdeploy/teams/Team.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface Team {
     String getId();
     String getDisplayName();
+    String getJenkinsFolder();
     List<ApplicationConfig> getApplicationConfigs();
 }

--- a/src/main/java/no/nav/fo/forenkletdeploy/teams/TeamOppfolging.java
+++ b/src/main/java/no/nav/fo/forenkletdeploy/teams/TeamOppfolging.java
@@ -18,6 +18,11 @@ public class TeamOppfolging implements Team {
     }
 
     @Override
+    public String getJenkinsFolder() {
+        return "teamoppfolging";
+    }
+
+    @Override
     public List<ApplicationConfig> getApplicationConfigs() {
         return Arrays.asList(
                 ApplicationConfig.builder()

--- a/src/main/java/no/nav/fo/forenkletdeploy/teams/TeamSoknad.java
+++ b/src/main/java/no/nav/fo/forenkletdeploy/teams/TeamSoknad.java
@@ -24,6 +24,11 @@ public class TeamSoknad implements Team {
     }
 
     @Override
+    public String getJenkinsFolder() {
+        return "team_soknad";
+    }
+
+    @Override
     public List<ApplicationConfig> getApplicationConfigs() {
         String json = withClient(c -> c.target("https://raw.githubusercontent.com/navikt/jenkins-dsl-scripts/master/team_soknad/config.json").request().get(String.class));
         Map<String, Map<String, String>> map = fromJson(json, Map.class);


### PR DESCRIPTION
Lenkene under promote-tabbben var hardkodet til FO-jenkins. Hvert team må nå spesifisere sin jenkinsfolder.

Lagt på deres kjente @etse, men fant på en til dere @Quist 

Får fortsatt ikke kjørt backenden opp, så @etse om du kjører opp og ser at jenkinsfolder blir levert fra teamsapiet hadde det vært kjempefint!