### PR TITLE
Fiks filtrering av applikasjoner i dashboard (ref. issue #84)

### DIFF
--- a/src/frontend/src/redux/selectors/application-selectors.ts
+++ b/src/frontend/src/redux/selectors/application-selectors.ts
@@ -2,6 +2,7 @@ import { AppState } from '../reducer';
 import { ApplicationWithChanges } from '../../models/application';
 import { getEnvironments } from '../../utils/environment';
 import { Environment } from '../../models/environment';
+import { selectMiljoerForValgtTeam } from '../team-velger-duck';
 
 export function selectApplications(state: AppState): string[] {
     const applications = state.deploy.deploys.map((deploy) => deploy.application);
@@ -34,5 +35,6 @@ export function selectApplicationsWithChangesForEnvironments(state: AppState, en
 }
 
 export function selectApplicationsWithChanges(state: AppState): ApplicationWithChanges[] {
-    return selectApplicationsWithChangesForEnvironments(state, getEnvironments());
+    const validEnvironments = selectMiljoerForValgtTeam(state);
+    return selectApplicationsWithChangesForEnvironments(state, validEnvironments);
 }


### PR DESCRIPTION
Dashboardets filtrering av apper uten kodeendringer fungerer ikke som tiltenkt. Et team har et sett med gyldige miljøer, f.eks. (q6, q0, p) for teamet "Forenklet Oppfølging", og det er endringer i koden mellom disse miljøene man er interessert i. Dersom en applikasjon har endring mellom gyldige og ikke-gyldige miljøer for teamet, f.eks. mellom t6 og q6 for "Forenklet Oppfølging", vil den fortsatt dukke opp i den filtrerte listen selv om man ikke er interessert i denne endringen ettersom t6 er et ugyldig miljø.

Denne fiksen sørger for at man bare tar hensyn til gyldige miljøer for teamet når listen av applikasjoner filtreres.