### PR TITLE
Fjernet T6 fra Team Aasmund

### DIFF
--- a/src/main/kotlin/no/nav/fo/forenkletdeploy/service/TeamService.kt
+++ b/src/main/kotlin/no/nav/fo/forenkletdeploy/service/TeamService.kt
@@ -74,7 +74,8 @@ class TeamPAMAasmund: ITeam(
         configUrl = "https://raw.githubusercontent.com/navikt/pam-scripts/master/applikasjonsportefolje/config-teamaasmund.json",
         jenkinsFolder = "teamaasmund",
         jenkinsUrl = "https://jenkins-pam.adeo.no",
-        provideVersion = true
+        provideVersion = true,
+        environments = listOf("Q6", "Q0", "P")
 )
 
 class TeamPAMTuan: ITeam(


### PR DESCRIPTION
Fjernet T6 fra miljøene som brukes av Team Aasmund (PAM). 